### PR TITLE
Update dependencies for Minecraft 1.21.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,5 +20,5 @@ baseVersion=1.0.3
 # Branch Metadata
 branch=1.21
 tagBranch=1.20
-compatibleVersions=1.21, 1.21.1
+compatibleVersions=1.21.8
 compatibleLoaders=fabric, quilt, neoforge

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
-loom = "1.7.+"
+loom = "1.11-SNAPSHOT"
 githubRelease = "2.4.1"
 minotaur = "2.+"
 
 kaleidoConfig = "0.3.1+1.3.2"
 
-mc = "1.21"
-fl = "0.15.11"
-yarn = "1.21+build.9"
-fapi = "0.101.2+1.21"
+mc = "1.21.8"
+fl = "0.16.14"
+yarn = "1.21.8+build.1"
+fapi = "0.129.0+1.21.8"
 
 [plugins]
 loom = { id = "fabric-loom", version.ref = "loom" }


### PR DESCRIPTION
## Summary
- bump Minecraft, Yarn, Fabric Loader, Fabric API, and Loom versions to the releases for Minecraft 1.21.8
- update the declared compatible Minecraft versions to 1.21.8

## Testing
- `./gradlew --refresh-dependencies` *(fails: cannot reach https://maven.fabricmc.net/ to download fabric-loom 1.11-SNAPSHOT)*
- `./gradlew genSources` *(fails for the same reason as above)*

------
https://chatgpt.com/codex/tasks/task_e_68d07f904a78832a9a65763360ee2309