### PR TITLE
Update compatibility metadata for Minecraft 1.21.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,10 +37,10 @@ processResources {
 		license       : license,
 		authors       : authors.split(", ").join("\",\n    \""),
 		members       : "${authors}",
-		mc            : compatibleVersions.split(", ")[0],
-		fl            : libs.versions.fl.get(),
-		fapi          : libs.versions.fapi.get()
-	]
+                mcVersion     : libs.versions.mc.get(),
+                fl            : libs.versions.fl.get(),
+                fapi          : libs.versions.fapi.get()
+        ]
 	inputs.properties(meta)
 	filesMatching("*.mod.json") { expand(meta) }
 	filesMatching("META-INF/*mods.toml") { expand(meta) }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ license=LGPL-3.0-or-later
 # Mod Version
 baseVersion=1.0.3
 # Branch Metadata
-branch=1.21
+branch=1.21.8
 tagBranch=1.20
 compatibleVersions=1.21.8
 compatibleLoaders=fabric, quilt, neoforge

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -32,7 +32,7 @@ side = "BOTH"
 [[dependencies.${ modId }]]
 modId = "minecraft"
 type = "required"
-versionRange = "[${mc},)"
+versionRange = "[${mcVersion},)"
 ordering = "NONE"
 side = "BOTH"
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,7 +21,7 @@
 	},
 	"depends": {
 		"fabricloader": ">=${fl}",
-		"minecraft": ">=${mc}",
+                "minecraft": ">=${mcVersion}",
 		"fabric-api": ">=${fapi}"
 	}
 }


### PR DESCRIPTION
## Summary
- bump the publishing branch metadata to 1.21.8
- expand resource filtering with the mcVersion catalog entry and update mod metadata to require Minecraft 1.21.8

## Testing
- `./gradlew build` *(fails: fabric-loom 1.11-SNAPSHOT plugin cannot be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d081d836a0832aa3e662ab958afb11