### PR TITLE
Add version-aware sound queue helper

### DIFF
--- a/src/main/java/folk/sisby/euphonium/sound/BiomeSound.java
+++ b/src/main/java/folk/sisby/euphonium/sound/BiomeSound.java
@@ -70,11 +70,11 @@ public abstract class BiomeSound implements ISoundInstance {
 
 			if (!isPlaying()) {
 				soundInstance = new LoopingSound(player, getSound(), (float) volume, getPitch(), p -> isValid);
-				try {
-					getSoundManager().play(this.soundInstance);
-				} catch (ConcurrentModificationException e) {
-					log.debug("[{}] Exception in tick", this.getClass().getSimpleName());
-				}
+                                try {
+                                        queueSound(this.soundInstance);
+                                } catch (ConcurrentModificationException e) {
+                                        log.debug("[{}] Exception in tick", this.getClass().getSimpleName());
+                                }
 			} else {
 
 				// Adjust sound volume with a fade.

--- a/src/main/java/folk/sisby/euphonium/sound/ISoundInstance.java
+++ b/src/main/java/folk/sisby/euphonium/sound/ISoundInstance.java
@@ -13,6 +13,9 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.biome.Biome;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 @SuppressWarnings("BooleanMethodIsAlwaysInverted")
 public interface ISoundInstance {
 	boolean isValid();
@@ -52,14 +55,34 @@ public interface ISoundInstance {
 		return MinecraftClient.getInstance();
 	}
 
-	default SoundManager getSoundManager() {
-		return getMinecraft().getSoundManager();
-	}
+        default SoundManager getSoundManager() {
+                return getMinecraft().getSoundManager();
+        }
 
-	default boolean isPlaying() {
-		return getSoundInstance() != null
-			&& getSoundManager().isPlaying(getSoundInstance());
-	}
+        default void queueSound(MovingSoundInstance instance) {
+                if (instance == null) {
+                        return;
+                }
+
+                var manager = getSoundManager();
+                var queueMethod = QueueSoundMethodHolder.METHOD;
+
+                if (queueMethod != null) {
+                        try {
+                                queueMethod.invoke(manager, instance);
+                                return;
+                        } catch (IllegalAccessException | InvocationTargetException e) {
+                                throw new RuntimeException("Failed to invoke SoundManager queue method", e);
+                        }
+                }
+
+                PlaySoundMethodHolder.invoke(manager, instance);
+        }
+
+        default boolean isPlaying() {
+                return getSoundInstance() != null
+                        && getSoundManager().isPlaying(getSoundInstance());
+        }
 
 	default void stop() {
 		getSoundManager().stop(getSoundInstance());
@@ -77,7 +100,47 @@ public interface ISoundInstance {
 		return 1.0F;
 	}
 
-	default double getVolumeScaling() {
-		return 1.0D;
-	}
+        default double getVolumeScaling() {
+                return 1.0D;
+        }
+
+        final class QueueSoundMethodHolder {
+                private static final Method METHOD = findMethod();
+
+                private static Method findMethod() {
+                        try {
+                                return SoundManager.class.getMethod("queueSound", MovingSoundInstance.class);
+                        } catch (NoSuchMethodException e) {
+                                return null;
+                        }
+                }
+        }
+
+        final class PlaySoundMethodHolder {
+                private static final Method METHOD = findMethod();
+
+                private static Method findMethod() {
+                        try {
+                                return SoundManager.class.getMethod("play", MovingSoundInstance.class);
+                        } catch (NoSuchMethodException e) {
+                                try {
+                                        return SoundManager.class.getMethod("play", net.minecraft.client.sound.SoundInstance.class);
+                                } catch (NoSuchMethodException ignored) {
+                                        return null;
+                                }
+                        }
+                }
+
+                private static void invoke(SoundManager manager, MovingSoundInstance instance) {
+                        if (METHOD == null) {
+                                throw new IllegalStateException("No compatible SoundManager#play method found");
+                        }
+
+                        try {
+                                METHOD.invoke(manager, instance);
+                        } catch (IllegalAccessException | InvocationTargetException e) {
+                                throw new RuntimeException("Failed to invoke legacy SoundManager#play", e);
+                        }
+                }
+        }
 }

--- a/src/main/java/folk/sisby/euphonium/sound/LoopedWorldSound.java
+++ b/src/main/java/folk/sisby/euphonium/sound/LoopedWorldSound.java
@@ -26,11 +26,11 @@ public abstract class LoopedWorldSound extends WorldSound {
 
 		if (isValid && !isPlaying()) {
 			soundInstance = new LoopingSound(player, getSound(), (float) (getVolume() * getVolumeScaling()), getPitch(), p -> isValid);
-			try {
-				getSoundManager().play(this.soundInstance);
-			} catch (ConcurrentModificationException e) {
-				EuphoniumClient.LOGGER.debug("{}: Exception in tick", this.getClass());
-			}
+                        try {
+                                queueSound(this.soundInstance);
+                        } catch (ConcurrentModificationException e) {
+                                EuphoniumClient.LOGGER.debug("{}: Exception in tick", this.getClass());
+                        }
 		}
 	}
 }

--- a/src/main/java/folk/sisby/euphonium/sound/RepeatedWorldSound.java
+++ b/src/main/java/folk/sisby/euphonium/sound/RepeatedWorldSound.java
@@ -32,15 +32,15 @@ public abstract class RepeatedWorldSound extends WorldSound {
 
 		if (isValid) {
 			soundInstance = new SingleSound(getPlayer(), getSound(), (float) (getVolume() * getVolumeScaling()), getPitch(), getPos());
-			var manager = getSoundManager();
+                        try {
+                                var manager = getSoundManager();
 
-			try {
-				if (!manager.isPlaying(soundInstance)) {
-					manager.play(soundInstance);
-				}
-			} catch (ConcurrentModificationException e) {
-				EuphoniumClient.LOGGER.debug("{}: Exception in manager.play", this.getClass());
-			}
+                                if (!manager.isPlaying(soundInstance)) {
+                                        queueSound(soundInstance);
+                                }
+                        } catch (ConcurrentModificationException e) {
+                                EuphoniumClient.LOGGER.debug("{}: Exception in queueSound", this.getClass());
+                        }
 		}
 	}
 


### PR DESCRIPTION
## Summary
- add a version-aware `queueSound` helper to `ISoundInstance` that defers to `SoundManager#queueSound` when available and uses the legacy play path otherwise
- route all ambient sound playback helpers through the new queue helper to avoid `NoSuchMethodError` on 1.21.8

## Testing
- `./gradlew compileJava` *(fails: fabric-loom 1.11-SNAPSHOT plugin unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d08b2d9a64832a9805e048c81c4f4b