### PR TITLE
Fix SoundManager descriptor generation

### DIFF
--- a/src/main/java/folk/sisby/euphonium/sound/ISoundInstance.java
+++ b/src/main/java/folk/sisby/euphonium/sound/ISoundInstance.java
@@ -160,6 +160,11 @@ public interface ISoundInstance {
                 private static final MappingResolver RESOLVER = FabricLoader.getInstance().getMappingResolver();
                 private static final String SOUND_MANAGER_CLASS = "net.minecraft.client.sound.SoundManager";
 
+                static {
+                        assert find("play", SoundInstance.class) != null :
+                                "SoundManager#play(SoundInstance) not found under current mappings";
+                }
+
                 private static Method find(String namedName, Class<?>... parameterTypes) {
                         String descriptor = getNamedMethodDescriptor(void.class, parameterTypes);
                         String runtimeName = RESOLVER.mapMethodName("named", SOUND_MANAGER_CLASS, namedName, descriptor);
@@ -180,6 +185,7 @@ public interface ISoundInstance {
                                 builder.append(getNamedDescriptor(parameterType));
                         }
 
+                        builder.append(')');
                         builder.append(getNamedDescriptor(returnType));
                         return builder.toString();
                 }


### PR DESCRIPTION
## Summary
- ensure the SoundManager method descriptor closes the parameter list before appending the return type
- add a defensive assertion that the mapped SoundManager#play(SoundInstance) method is present under current mappings

## Testing
- GRADLE_USER_HOME=/tmp/gradle ./gradlew --no-daemon --console=plain check

------
https://chatgpt.com/codex/tasks/task_e_68d10c3bfdec832a9d5fb6b4463186c5