### PR TITLE
Update Fabric dependencies to Minecraft 1.21.8

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
-loom = "1.7.+"
+loom = "1.10.5"
 githubRelease = "2.4.1"
 minotaur = "2.+"
 
 kaleidoConfig = "0.3.1+1.3.2"
 
-mc = "1.21"
-fl = "0.15.11"
-yarn = "1.21+build.9"
-fapi = "0.101.2+1.21"
+mc = "1.21.8"
+fl = "0.17.2"
+yarn = "1.21.8+build.1"
+fapi = "0.133.4+1.21.8"
 
 [plugins]
 loom = { id = "fabric-loom", version.ref = "loom" }

--- a/src/main/java/folk/sisby/euphonium/sound/ISoundInstance.java
+++ b/src/main/java/folk/sisby/euphonium/sound/ISoundInstance.java
@@ -38,8 +38,8 @@ public interface ISoundInstance {
 
 	default RegistryKey<Biome> getBiomeKey(BlockPos pos) {
 		var biome = getBiome(pos);
-		return getLevel().getRegistryManager()
-			.get(RegistryKeys.BIOME)
+                return getLevel().getRegistryManager()
+                        .getOrThrow(RegistryKeys.BIOME)
 			.getKey(biome)
 			.orElse(null);
 	}

--- a/src/main/java/folk/sisby/euphonium/sounds/world/High.java
+++ b/src/main/java/folk/sisby/euphonium/sounds/world/High.java
@@ -23,7 +23,7 @@ public class High implements ISoundType<WorldSound> {
 		handler.getSounds().add(new RepeatedWorldSound(handler.getPlayer()) {
 			@Override
 			public boolean isValidSituationCondition() {
-				int top = level.getTopY() > 256 ? 200 : 150;
+                                int top = level.getDimension().logicalHeight() > 256 ? 200 : 150;
 
 				return level.getRegistryKey() == World.OVERWORLD
 					&& player.getBlockPos().getY() > top;


### PR DESCRIPTION
## Summary
- bump Fabric loader, API, Yarn, and Loom versions to target Minecraft 1.21.8
- point the Gradle wrapper configuration at Gradle 8.14 while keeping the bundled jar untouched to avoid binary diffs
- update biome registry lookup and overworld height logic for the new mappings

## Testing
- ./gradlew genSources --console=plain
- ./gradlew build --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d1265efc2c832a84f1782dfb9417bf